### PR TITLE
Fix `npm run build:ios` error related to that uglify-js does not support ES6 by changing minification to Terser

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -119,7 +119,7 @@ module.exports = async (api, options, rootOptions) => {
       dependencies: {},
       devDependencies: {
         'fork-ts-checker-webpack-plugin': '^0.4.15',
-        'uglifyjs-webpack-plugin': '^2.0.1'
+        'terser-webpack-plugin': '^1.2.3'
         //'tns-platform-declarations': '^4.2.1'
       }
     });

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const DefinePlugin = require('webpack/lib/DefinePlugin');
 // // // const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const nativescriptTarget = require('nativescript-dev-webpack/nativescript-target');
 const NsVueTemplateCompiler = require('nativescript-vue-template-compiler');
@@ -280,10 +280,10 @@ const nativeConfig = (api, projectOptions, env, jsOrTs, projectRoot, platform) =
     config.optimization.minimize(Boolean(production));
     config.optimization
       .minimizer([
-        new UglifyJsPlugin({
+        new TerserPlugin({
           parallel: true,
           cache: true,
-          uglifyOptions: {
+          terserOptions: {
             output: {
               comments: false
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-nativescript-vue",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "A vue cli 3.x plugin for NativeScript-Vue",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
<img width="959" alt="Screen Shot 2019-03-13 at 13 51 43" src="https://user-images.githubusercontent.com/136875/54308255-eab73c00-45cd-11e9-9a8c-7b9ddd60149d.png">
